### PR TITLE
feat: add new chat functionality to ChatHeader and ChatUI components

### DIFF
--- a/components/chat-header.tsx
+++ b/components/chat-header.tsx
@@ -11,6 +11,7 @@ export type ChatHeaderProps = {
   onSelectModel: (model: Model) => void;
   isModelOpen: boolean;
   onModelOpenChange: (open: boolean) => void;
+  onNewChat?: () => void;
 };
 
 export function ChatHeader({
@@ -19,10 +20,21 @@ export function ChatHeader({
   onSelectModel,
   isModelOpen,
   onModelOpenChange,
+  onNewChat,
 }: ChatHeaderProps) {
   return (
     <header className="flex h-14 items-center justify-between border-b px-4 lg:px-8 bg-background/80 backdrop-blur-sm sticky top-0 z-10">
-      <div className="flex items-center gap-2">
+      <div 
+        className="flex items-center gap-2 cursor-pointer hover:opacity-80 transition-opacity" 
+        onClick={onNewChat}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            onNewChat?.();
+          }
+        }}
+      >
         <div className="flex items-center justify-center size-8 rounded-lg bg-primary/10 text-primary">
           <TreePine className="size-4" />
         </div>

--- a/components/chat-ui.tsx
+++ b/components/chat-ui.tsx
@@ -124,6 +124,13 @@ export function ChatUI() {
     setAttachments((prev) => prev.filter((_, i) => i !== index));
   }, []);
 
+  const handleNewChat = useCallback(() => {
+    setMessages([]);
+    setAttachments([]);
+    setInputValue("");
+    localStorage.removeItem(STORAGE_KEYS.MESSAGES);
+  }, [setMessages]);
+
   const handleSubmit = async (value: { text: string; files: any[] }) => {
     if (!value.text.trim() && value.files.length === 0) return;
 
@@ -183,6 +190,7 @@ export function ChatUI() {
         onSelectModel={setSelectedModel}
         isModelOpen={isModelOpen}
         onModelOpenChange={setIsModelOpen}
+        onNewChat={handleNewChat}
       />
 
       {/* Main Content Area */}

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
-        "baseline-browser-mapping": "^2.8.32",
         "eslint": "^9",
         "eslint-config-next": "16.0.7",
         "tailwindcss": "^4",


### PR DESCRIPTION
This pull request adds a "New Chat" feature to the chat UI, allowing users to quickly start a new conversation. The main changes include updating the `ChatHeader` component to support a new chat action and implementing the logic to reset the chat state when triggered.

**New Chat Feature Implementation**

* Added an optional `onNewChat` prop to the `ChatHeaderProps` type and updated the header UI to handle clicks and keyboard events for starting a new chat (`components/chat-header.tsx`). [[1]](diffhunk://#diff-1c842058aecb8359df1e768abe367bcdbd2936a2539fb9b6384449621f567039R14) [[2]](diffhunk://#diff-1c842058aecb8359df1e768abe367bcdbd2936a2539fb9b6384449621f567039R23-R37)
* Implemented the `handleNewChat` function in `ChatUI` to clear messages, attachments, input value, and remove persisted messages from local storage (`components/chat-ui.tsx`).
* Passed the `handleNewChat` function to the `ChatHeader` component as the `onNewChat` prop (`components/chat-ui.tsx`).