### PR TITLE
Add voice transcription UX states to prompt input

### DIFF
--- a/components/ai-elements/prompt-input.tsx
+++ b/components/ai-elements/prompt-input.tsx
@@ -1149,7 +1149,9 @@ export const PromptInputSpeechButton = ({
   onTranscriptionChange,
   ...props
 }: PromptInputSpeechButtonProps) => {
+  const [isSupported, setIsSupported] = useState(true);
   const [isListening, setIsListening] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [recognition, setRecognition] = useState<SpeechRecognition | null>(
     null
   );
@@ -1160,6 +1162,7 @@ export const PromptInputSpeechButton = ({
       typeof window !== "undefined" &&
       ("SpeechRecognition" in window || "webkitSpeechRecognition" in window)
     ) {
+      setIsSupported(true);
       const SpeechRecognition =
         window.SpeechRecognition || window.webkitSpeechRecognition;
       const speechRecognition = new SpeechRecognition();
@@ -1170,6 +1173,7 @@ export const PromptInputSpeechButton = ({
 
       speechRecognition.onstart = () => {
         setIsListening(true);
+        setErrorMessage(null);
       };
 
       speechRecognition.onend = () => {
@@ -1200,11 +1204,14 @@ export const PromptInputSpeechButton = ({
 
       speechRecognition.onerror = (event) => {
         console.error("Speech recognition error:", event.error);
+        setErrorMessage(event.error);
         setIsListening(false);
       };
 
       recognitionRef.current = speechRecognition;
       setRecognition(speechRecognition);
+    } else {
+      setIsSupported(false);
     }
 
     return () => {
@@ -1215,29 +1222,47 @@ export const PromptInputSpeechButton = ({
   }, [textareaRef, onTranscriptionChange]);
 
   const toggleListening = useCallback(() => {
-    if (!recognition) {
+    if (!recognition || !isSupported) {
       return;
     }
 
     if (isListening) {
       recognition.stop();
     } else {
+      setErrorMessage(null);
       recognition.start();
     }
-  }, [recognition, isListening]);
+  }, [recognition, isListening, isSupported]);
+
+  const tooltipText = !isSupported
+    ? "Voice input isn't supported in this browser"
+    : isListening
+      ? "Stop voice input"
+      : errorMessage
+        ? "Microphone access failed. Click to retry"
+        : "Start voice input";
 
   return (
     <PromptInputButton
       className={cn(
         "relative transition-all duration-200",
         isListening && "animate-pulse bg-accent text-accent-foreground",
+        errorMessage && "text-destructive",
         className
       )}
-      disabled={!recognition}
+      aria-pressed={isListening}
+      aria-label={tooltipText}
+      disabled={!recognition || !isSupported}
       onClick={toggleListening}
+      tooltip={tooltipText}
       {...props}
     >
-      <MicIcon className="size-4" />
+      {isListening ? (
+        <SquareIcon className="size-4" />
+      ) : (
+        <MicIcon className="size-4" />
+      )}
+      <span className="sr-only">{tooltipText}</span>
     </PromptInputButton>
   );
 };

--- a/components/prompt-input-area.tsx
+++ b/components/prompt-input-area.tsx
@@ -203,7 +203,14 @@ export function PromptInputArea({
 
           <ButtonGroupSeparator className="h-6 mb-2 self-end!" />
 
-          <PromptInputSpeechButton className="rounded-none border-none shadow-none h-10 w-10 p-0 flex items-center justify-center shrink-0" />
+          <PromptInputSpeechButton
+            className="rounded-none border-none shadow-none h-10 w-10 p-0 flex items-center justify-center shrink-0"
+            textareaRef={textareaRef}
+            onTranscriptionChange={(text) => {
+              onChange(text);
+              textareaRef.current?.focus();
+            }}
+          />
 
           {/* Tool Pills inside input */}
           {mentionedTools.length > 0 && (


### PR DESCRIPTION
### Motivation
- Provide a robust voice transcription experience for the prompt input with explicit UI states (supported, listening, error) and accessible tooling in accordance with UX guidance. 

### Description
- Added support and error state tracking via `isSupported` and `errorMessage` to `PromptInputSpeechButton` in `components/ai-elements/prompt-input.tsx`. 
- Surface contextual tooltip text and accessibility attributes with `aria-label` and `aria-pressed`, and disable the button when speech recognition is unavailable. 
- Show a distinct icon/state when listening and apply an error visual (`text-destructive`) when microphone access fails, and expose `tooltip` messaging. 
- Wired speech results into the main input by passing `textareaRef` and `onTranscriptionChange` from `components/prompt-input-area.tsx` to the speech button so transcriptions update the textarea and restore focus. 

### Testing
- Started the dev server with `npm run dev` and the Next.js dev server reported `Ready` (server startup succeeded). 
- Attempted an automated Playwright screenshot flow to validate the UI, but the Chromium instance crashed during the run and the Playwright check failed with a browser crash error. 
- No unit tests were run as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981af9dc3e083238f3a64248dcbbb27)