### PR TITLE
Add @slides multi-step tooling and UI flow

### DIFF
--- a/ai/prompts/slides.ts
+++ b/ai/prompts/slides.ts
@@ -1,0 +1,19 @@
+export const SLIDES_AGENT_PROMPT = `You are the @slides presentation creation agent.
+
+Workflow requirements:
+1) When a user asks to create a presentation, first generate a structured SlideOutline and call reviewSlideOutline.
+2) The outline should usually contain 8-15 slides unless the user asks for a specific count.
+3) Use varied slide types across the deck: title, content, section-divider, two-column, image-focus, quote.
+4) Include concise slide bullets and optional speaker notes.
+5) After outline review, if user accepted/edited it, call searchUnsplashImages with descriptive queries tied to slide IDs.
+6) Then call createGoogleSlidesPresentation with the final outline and image assignments.
+7) If the user rejects the outline, regenerate the outline using their feedback and call reviewSlideOutline again.
+
+Design guidance:
+- Keep titles short and clear.
+- Favor one idea per slide.
+- Use high contrast color combinations.
+- Keep bullets crisp, non-redundant, and presentation-friendly.
+- Suggested theme palettes: modern blue (#2563EB), green sustainability (#16A34A), warm accent (#F59E0B), charcoal text (#1F2937).
+
+Never skip the reviewSlideOutline step for presentation creation requests.`;

--- a/ai/slides-tools.ts
+++ b/ai/slides-tools.ts
@@ -1,0 +1,114 @@
+import { tool } from "ai";
+import { z } from "zod";
+import { searchImages } from "@/lib/unsplash";
+import { generatePptxBuffer } from "@/lib/pptx-generator";
+import { uploadPresentationToDrive, setFilePermission } from "@/lib/google-slides";
+
+const slideTypeSchema = z.enum(["title", "content", "section-divider", "two-column", "image-focus", "quote"]);
+
+export const slideDefinitionSchema = z.object({
+  id: z.string(),
+  type: slideTypeSchema,
+  title: z.string(),
+  subtitle: z.string().optional(),
+  content: z.array(z.string()).default([]),
+  speakerNotes: z.string().optional(),
+  imageQuery: z.string().optional(),
+  imageUrl: z.string().optional(),
+  quoteText: z.string().optional(),
+  quoteAttribution: z.string().optional(),
+});
+
+export const slideOutlineSchema = z.object({
+  title: z.string(),
+  theme: z.object({
+    primaryColor: z.string(),
+    secondaryColor: z.string(),
+    accentColor: z.string(),
+    fontFamily: z.string(),
+  }),
+  slides: z.array(slideDefinitionSchema).min(1),
+});
+
+const imageAssignmentsSchema = z.array(z.object({
+  slideId: z.string(),
+  imageUrl: z.string().url(),
+  photographer: z.string().optional(),
+  altDescription: z.string().optional(),
+}));
+
+export const slidesTools = {
+  reviewSlideOutline: tool({
+    description: "Client-side review/edit step for a generated slide outline.",
+    inputSchema: slideOutlineSchema,
+  }),
+
+  searchUnsplashImages: tool({
+    description: "Search Unsplash images for presentation slides.",
+    inputSchema: z.object({
+      queries: z.array(
+        z.object({
+          slideId: z.string(),
+          query: z.string(),
+          count: z.number().int().min(1).max(5).optional(),
+        })
+      ),
+    }),
+    execute: async ({ queries }) => {
+      const results = await Promise.all(
+        queries.map(async (queryItem) => {
+          try {
+            const images = await searchImages(queryItem.query, queryItem.count || 2);
+            return { slideId: queryItem.slideId, images };
+          } catch (error) {
+            return {
+              slideId: queryItem.slideId,
+              images: [],
+              error: error instanceof Error ? error.message : "Failed to fetch images",
+            };
+          }
+        })
+      );
+
+      return { results };
+    },
+  }),
+
+  createGoogleSlidesPresentation: tool({
+    description: "Create and upload a presentation to Google Slides via Drive conversion.",
+    inputSchema: z.object({
+      outline: slideOutlineSchema,
+      imageAssignments: imageAssignmentsSchema.optional().default([]),
+      makePublic: z.boolean().optional().default(true),
+    }),
+    // @ts-expect-error AI SDK v6 runtime supports needsApproval for server-side tool gating.
+    needsApproval: true,
+    execute: async ({ outline, imageAssignments, makePublic }) => {
+      const assignmentMap = new Map(imageAssignments.map((item) => [item.slideId, item.imageUrl]));
+      const finalOutline = {
+        ...outline,
+        slides: outline.slides.map((slide) => ({
+          ...slide,
+          imageUrl: assignmentMap.get(slide.id) || slide.imageUrl,
+        })),
+      };
+
+      const pptxBuffer = await generatePptxBuffer(finalOutline);
+      const uploadResult = await uploadPresentationToDrive(`${outline.title}.pptx`, pptxBuffer);
+
+      if (makePublic) {
+        await setFilePermission(uploadResult.fileId, "reader", "anyone");
+      }
+
+      return {
+        status: "created" as const,
+        slidesUrl: uploadResult.webViewLink,
+        webViewLink: uploadResult.webViewLink,
+        thumbnailLink: uploadResult.thumbnailLink,
+        fileId: uploadResult.fileId,
+        slideCount: outline.slides.length,
+        title: outline.title,
+      };
+    },
+  }),
+};

--- a/app/api/auth/google/callback/route.ts
+++ b/app/api/auth/google/callback/route.ts
@@ -12,6 +12,7 @@ function getHtmlResponse(title: string, message: string, success: boolean, userI
   // Send different message types based on which service was authorized
   const messageType = service === 'forms' ? 'GOOGLE_FORMS_AUTH_SUCCESS' 
     : service === 'tasks' ? 'GOOGLE_TASKS_AUTH_SUCCESS'
+    : service === 'slides' ? 'GOOGLE_SLIDES_AUTH_SUCCESS'
     : service === 'all' ? 'GOOGLE_ALL_AUTH_SUCCESS'
     : 'GOOGLE_AUTH_SUCCESS';
   
@@ -102,6 +103,7 @@ export async function GET(request: Request) {
     storeTokens(userId, tokens);
 
     const serviceName = service === 'forms' ? 'Google Forms' 
+      : service === 'slides' ? 'Google Slides'
       : service === 'all' ? 'Google Calendar & Forms'
       : 'Google Calendar';
     console.log(`${serviceName} connected successfully for user:`, userId);

--- a/app/api/auth/google/route.ts
+++ b/app/api/auth/google/route.ts
@@ -8,12 +8,12 @@ const DEFAULT_USER_ID = "default-user";
  * GET /api/auth/google - Initiate Google OAuth flow or check status
  * Query params:
  *   - action=status: Check if connected
- *   - service=calendar|forms|tasks|all: Which service to authorize (default: calendar)
+ *   - service=calendar|forms|tasks|slides|all: Which service to authorize (default: calendar)
  */
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const action = searchParams.get("action");
-  const service = (searchParams.get("service") as 'calendar' | 'forms' | 'tasks' | 'all') || 'calendar';
+  const service = (searchParams.get("service") as 'calendar' | 'forms' | 'tasks' | 'slides' | 'all') || 'calendar';
 
   // Check connection status
   if (action === "status") {
@@ -22,6 +22,7 @@ export async function GET(request: Request) {
     const hasCalendarScopes = tokens?.scope?.includes("calendar");
     const hasFormsScopes = tokens?.scope?.includes("forms.body");
     const hasTasksScopes = tokens?.scope?.includes("tasks");
+    const hasSlidesScopes = tokens?.scope?.includes("drive.file");
     
     return Response.json({
       connected: !!tokens,
@@ -29,6 +30,7 @@ export async function GET(request: Request) {
       hasCalendarScopes,
       hasFormsScopes,
       hasTasksScopes,
+      hasSlidesScopes,
       scopes: tokens?.scope,
     });
   }

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -9,6 +9,8 @@ import { calendarTools } from "@/ai/calendar-tools";
 import { formsTools } from "@/ai/forms-tools";
 import { gmailTools } from "@/ai/gmail-tools";
 import { tasksTools } from "@/ai/tasks-tools";
+import { slidesTools } from "@/ai/slides-tools";
+import { SLIDES_AGENT_PROMPT } from "@/ai/prompts/slides";
 // PDF tools removed — handled entirely client-side to avoid tool part serialization issues
 import { GMAIL_AGENT_PROMPT } from "@/ai/prompts/gmail";
 import { isToolInstalled } from "@/lib/installed-tools";
@@ -479,6 +481,17 @@ Remember: Return ONLY the markdown code block with mermaid syntax. No additional
           console.warn("Tasks tool mentioned but not installed");
         }
       }
+      // Slides tools
+      if (["slides", "presentation", "ppt"].includes(lowerToolName)) {
+        if (isToolInstalled("slides")) {
+          tools.reviewSlideOutline = slidesTools.reviewSlideOutline;
+          tools.searchUnsplashImages = slidesTools.searchUnsplashImages;
+          tools.createGoogleSlidesPresentation = slidesTools.createGoogleSlidesPresentation;
+        } else {
+          console.warn("Slides tool mentioned but not installed");
+        }
+      }
+
       // PDF tools — handled entirely client-side (no LLM involvement)
       // The @pdf mention is intercepted in chat-ui.tsx before reaching this route
       // Add more tool mappings here as needed
@@ -515,6 +528,10 @@ Remember: Return ONLY the markdown code block with mermaid syntax. No additional
 
   const tasksGuidance = mentionedTools.some(t => ["tasks", "task", "todo", "todos"].includes(t.toLowerCase()))
     ? " When the user wants to create a task/todo, use scheduleTask to present the task details for confirmation. For listing tasks, use listTasks. To mark tasks complete, use completeTask. For updating task details, use updateTask. For deleting tasks, use deleteTask (which requires confirmation). Always parse relative dates like 'tomorrow', 'next week' into proper ISO dates. CRITICAL: After calling any task tool (scheduleTask, createTask, updateTask, deleteTask, completeTask, listTasks), DO NOT provide any additional text explanation. The generative UI component displays all necessary information to the user. ONLY provide additional text if you need clarification from the user (e.g., asking which task to update if there are multiple matches)."
+    : "";
+
+  const slidesGuidance = mentionedTools.some(t => ["slides", "presentation", "ppt"].includes(t.toLowerCase()))
+    ? ` ${SLIDES_AGENT_PROMPT}`
     : "";
 
   // PDF guidance removed — PDF operations are handled client-side
@@ -573,13 +590,22 @@ Remember: Return ONLY the markdown code block with mermaid syntax. No additional
 
       const result = streamText({
         model: modelInstance,
-        system: `${systemPrompt}${calendarGuidance}${formsGuidance}${tasksGuidance}`,
+        system: `${systemPrompt}${calendarGuidance}${formsGuidance}${tasksGuidance}${slidesGuidance}`,
         messages: modelMessages,
         tools: hasCurrentTools ? currentTools : undefined,
         toolChoice: hasCurrentTools ? "auto" : "none",
         providerOptions,
         // Use stopWhen for multi-step tool calls when custom tools are mentioned
         ...(mentionedTools.length > 0 && { stopWhen: stepCountIs(5) }),
+        experimental_repairToolCall: mentionedTools.some((t) => ["slides", "presentation", "ppt"].includes(t.toLowerCase()))
+          ? async ({ toolCall, tools }) => {
+              if (!toolCall || !toolCall.toolName || !(toolCall.toolName in tools)) return null;
+              return {
+                ...toolCall,
+                input: toolCall.input ?? {},
+              };
+            }
+          : undefined,
         onError: (error) => {
           console.error("Stream error:", error);
         },

--- a/app/api/slides/upload/route.ts
+++ b/app/api/slides/upload/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { uploadPresentationToDrive, setFilePermission } from "@/lib/google-slides";
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { name, pptxBase64, makePublic = true } = body;
+
+    if (!name || !pptxBase64) {
+      return NextResponse.json({ error: "name and pptxBase64 are required" }, { status: 400 });
+    }
+
+    const buffer = Buffer.from(pptxBase64, "base64");
+    const result = await uploadPresentationToDrive(name, buffer);
+
+    if (makePublic) {
+      await setFilePermission(result.fileId, "reader", "anyone");
+    }
+
+    return NextResponse.json({
+      success: true,
+      ...result,
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : "Slides upload failed",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/tools/marketplace/route.ts
+++ b/app/api/tools/marketplace/route.ts
@@ -47,6 +47,14 @@ const marketplaceTools = [
     icon: "mail",
     enabled: true,
   },
+  {
+    id: "slides",
+    name: "Slides",
+    description: "Generate and upload AI-powered presentations to Google Slides",
+    category: "productivity",
+    icon: "presentation",
+    enabled: true,
+  },
   // Add more tools here as needed
 ];
 

--- a/components/ai-elements/message-list.tsx
+++ b/components/ai-elements/message-list.tsx
@@ -47,6 +47,9 @@ import { TaskDeleteConfirmation } from "@/components/ai-elements/task-delete-con
 import { TaskUpdateConfirmation } from "@/components/ai-elements/task-update-confirmation";
 import { TaskCompleteDisplay } from "@/components/ai-elements/task-complete-display";
 import { PdfResult, PdfLoading } from "@/components/ai-elements/pdf-result";
+import { SlideOutlineEditor } from "@/components/ai-elements/slide-outline-editor";
+import { SlidesResult } from "@/components/ai-elements/slides-result";
+import { SlidesApproval } from "@/components/ai-elements/slides-approval";
 import {
   CopyIcon,
   RefreshCwIcon,
@@ -76,9 +79,11 @@ export type MessageListProps = {
   status: ChatStatus;
   onRegenerate: () => void;
   error?: Error | undefined;
+  addToolOutput?: (arg: { toolCallId: string; output: string }) => void;
+  addToolApprovalResponse?: (arg: { id: string; approved: boolean }) => void;
 };
 
-export function MessageList({ messages, isLoading, status, onRegenerate, error }: MessageListProps) {
+export function MessageList({ messages, isLoading, status, onRegenerate, error, addToolOutput, addToolApprovalResponse }: MessageListProps) {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
   const [mounted, setMounted] = useState(false);
@@ -228,6 +233,7 @@ const normalizedToolInvocations = toolInvocations.reduce((acc: any[], ti: any, t
       state,
       args: t.args || t.input || {},
       result: t.result || t.output || null,
+      approval: t.approval,
     });
   }
 
@@ -430,6 +436,52 @@ const normalizedToolInvocations = toolInvocations.reduce((acc: any[], ti: any, t
                                 completedAt={toolInvocation.result.completedAt}
                               />
                             );
+                          }
+                        }
+
+                        if (toolInvocation.toolName === "reviewSlideOutline") {
+                          if (toolInvocation.state === "call" || toolInvocation.state === "input-available") {
+                            return (
+                              <SlideOutlineEditor
+                                key={toolInvocation.toolCallId}
+                                toolCallId={toolInvocation.toolCallId}
+                                input={toolInvocation.args}
+                                addToolOutput={addToolOutput}
+                              />
+                            );
+                          }
+                        }
+
+                        if (toolInvocation.toolName === "searchUnsplashImages") {
+                          if (!isCompleted) {
+                            return <div key={toolInvocation.toolCallId} className="text-xs text-muted-foreground">Searching Unsplash images…</div>;
+                          }
+
+                          const allImages = (toolInvocation.result?.results || []).flatMap((r: any) => r.images || []);
+                          if (allImages.length > 0) {
+                            return (
+                              <div key={toolInvocation.toolCallId} className="grid grid-cols-3 gap-2">
+                                {allImages.slice(0, 6).map((image: any, idx: number) => (
+                                  <img key={`${image.id || idx}`} src={image.thumbUrl || image.url} alt={image.altDescription || "Unsplash"} className="rounded-md border" />
+                                ))}
+                              </div>
+                            );
+                          }
+                        }
+
+                        if (toolInvocation.toolName === "createGoogleSlidesPresentation") {
+                          if (toolInvocation.state === "approval-requested") {
+                            return (
+                              <SlidesApproval
+                                key={toolInvocation.toolCallId}
+                                part={toolInvocation}
+                                addToolApprovalResponse={addToolApprovalResponse}
+                              />
+                            );
+                          }
+
+                          if (isCompleted) {
+                            return <SlidesResult key={toolInvocation.toolCallId} result={toolInvocation.result} />;
                           }
                         }
 

--- a/components/ai-elements/slide-outline-editor.tsx
+++ b/components/ai-elements/slide-outline-editor.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { motion } from "motion/react";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+
+type SlideType = "title" | "content" | "section-divider" | "two-column" | "image-focus" | "quote";
+
+interface SlideOutlineEditorProps {
+  toolCallId: string;
+  input: any;
+  addToolOutput?: (arg: { toolCallId: string; output: string }) => void;
+}
+
+export function SlideOutlineEditor({ toolCallId, input, addToolOutput }: SlideOutlineEditorProps) {
+  const [outline, setOutline] = useState<any>(input);
+
+  const slides = useMemo(() => outline?.slides || [], [outline]);
+
+  const updateSlide = (idx: number, patch: any) => {
+    setOutline((prev: any) => ({
+      ...prev,
+      slides: prev.slides.map((s: any, i: number) => (i === idx ? { ...s, ...patch } : s)),
+    }));
+  };
+
+  return (
+    <Card className="p-4 space-y-4 w-full">
+      <h3 className="text-sm font-semibold">Review Slide Outline</h3>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <Input
+          value={outline?.title || ""}
+          onChange={(e) => setOutline((prev: any) => ({ ...prev, title: e.target.value }))}
+          placeholder="Presentation title"
+        />
+        <Input
+          value={outline?.theme?.fontFamily || "Aptos"}
+          onChange={(e) => setOutline((prev: any) => ({ ...prev, theme: { ...prev.theme, fontFamily: e.target.value } }))}
+          placeholder="Font family"
+        />
+      </div>
+
+      <div className="grid gap-2 sm:grid-cols-3">
+        <Input type="color" value={outline?.theme?.primaryColor || "#2563eb"} onChange={(e) => setOutline((prev: any) => ({ ...prev, theme: { ...prev.theme, primaryColor: e.target.value } }))} />
+        <Input type="color" value={outline?.theme?.secondaryColor || "#0f172a"} onChange={(e) => setOutline((prev: any) => ({ ...prev, theme: { ...prev.theme, secondaryColor: e.target.value } }))} />
+        <Input type="color" value={outline?.theme?.accentColor || "#f59e0b"} onChange={(e) => setOutline((prev: any) => ({ ...prev, theme: { ...prev.theme, accentColor: e.target.value } }))} />
+      </div>
+
+      <div className="space-y-3">
+        {slides.map((slide: any, index: number) => (
+          <motion.div key={slide.id || index} layout className="border rounded-lg p-3 space-y-2">
+            <div className="grid gap-2 sm:grid-cols-2">
+              <Input value={slide.title || ""} onChange={(e) => updateSlide(index, { title: e.target.value })} placeholder="Slide title" />
+              <Select value={slide.type || "content"} onValueChange={(value: SlideType) => updateSlide(index, { type: value })}>
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="title">title</SelectItem>
+                  <SelectItem value="content">content</SelectItem>
+                  <SelectItem value="section-divider">section-divider</SelectItem>
+                  <SelectItem value="two-column">two-column</SelectItem>
+                  <SelectItem value="image-focus">image-focus</SelectItem>
+                  <SelectItem value="quote">quote</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <Textarea
+              value={(slide.content || []).join("\n")}
+              onChange={(e) => updateSlide(index, { content: e.target.value.split("\n").filter(Boolean) })}
+              placeholder="One bullet per line"
+              rows={4}
+            />
+          </motion.div>
+        ))}
+      </div>
+
+      <div className="flex gap-2 justify-end">
+        <Button
+          variant="outline"
+          onClick={() => addToolOutput?.({ toolCallId, output: JSON.stringify({ rejected: true, reason: "User requested a rewrite" }) })}
+        >
+          Reject / Start Over
+        </Button>
+        <Button onClick={() => addToolOutput?.({ toolCallId, output: JSON.stringify(outline) })}>Confirm Outline</Button>
+      </div>
+    </Card>
+  );
+}

--- a/components/ai-elements/slides-approval.tsx
+++ b/components/ai-elements/slides-approval.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+interface SlidesApprovalProps {
+  part: any;
+  addToolApprovalResponse?: (arg: { id: string; approved: boolean }) => void;
+}
+
+export function SlidesApproval({ part, addToolApprovalResponse }: SlidesApprovalProps) {
+  const outline = part?.args?.outline;
+  const slideTitles = outline?.slides?.map((s: any) => s.title) || [];
+
+  return (
+    <Card className="p-4 space-y-3">
+      <h3 className="text-sm font-semibold">Ready to create Google Slides presentation?</h3>
+      <p className="text-xs text-muted-foreground">{outline?.title} · {outline?.slides?.length || 0} slides</p>
+      <ul className="text-xs text-muted-foreground list-disc pl-4 max-h-40 overflow-auto">
+        {slideTitles.map((title: string, i: number) => <li key={`${title}-${i}`}>{title}</li>)}
+      </ul>
+      <div className="flex gap-2 justify-end">
+        <Button variant="outline" onClick={() => addToolApprovalResponse?.({ id: part.approval.id, approved: false })}>Cancel</Button>
+        <Button onClick={() => addToolApprovalResponse?.({ id: part.approval.id, approved: true })}>Create & Upload</Button>
+      </div>
+    </Card>
+  );
+}

--- a/components/ai-elements/slides-result.tsx
+++ b/components/ai-elements/slides-result.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+interface SlidesResultProps {
+  result: any;
+}
+
+export function SlidesResult({ result }: SlidesResultProps) {
+  if (!result || result.error) {
+    return <Card className="p-4 text-sm text-destructive">Failed to create Google Slides presentation.</Card>;
+  }
+
+  return (
+    <Card className="p-4 space-y-3">
+      <div>
+        <h3 className="text-sm font-semibold">{result.title || "Presentation created"}</h3>
+        <p className="text-xs text-muted-foreground">{result.slideCount || 0} slides</p>
+      </div>
+      {result.thumbnailLink ? <img src={result.thumbnailLink} alt="Slides thumbnail" className="rounded-md border" /> : null}
+      <Button asChild>
+        <a href={result.webViewLink || result.slidesUrl} target="_blank" rel="noreferrer">Open in Google Slides</a>
+      </Button>
+    </Card>
+  );
+}

--- a/components/chat-ui.tsx
+++ b/components/chat-ui.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo } from "react";
 import { useChat } from "@ai-sdk/react";
-import { DefaultChatTransport } from "ai";
+import { DefaultChatTransport, lastAssistantMessageIsCompleteWithToolCalls } from "ai";
 import { motion } from "motion/react";
 import { cn } from "@/lib/utils";
 import type { MyUIMessage, PdfOperationResult } from "@/types/chat";
@@ -56,12 +56,15 @@ export function ChatUI() {
     error,
     regenerate,
     setMessages,
+    addToolOutput,
+    addToolApprovalResponse,
   } = useChat<MyUIMessage>({
     id: "gemini-chat",
     transport: new DefaultChatTransport({
       api: "/api/chat",
     }),
     experimental_throttle: 50, // Throttle UI updates for better performance
+    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
     onFinish: () => {
       setAttachments([]);
       // Clear the file input
@@ -436,6 +439,8 @@ export function ChatUI() {
             onRegenerate={handleRegenerate}
             status={status}
             error={error}
+            addToolOutput={addToolOutput}
+            addToolApprovalResponse={addToolApprovalResponse}
           />
         </div>
 

--- a/components/integrations-modal.tsx
+++ b/components/integrations-modal.tsx
@@ -8,7 +8,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { CloudSun, Plus, Trash2, ExternalLink, Calendar, FileText, Mail, ListTodo, Network, FileStack } from "lucide-react";
+import { CloudSun, Plus, Trash2, ExternalLink, Calendar, FileText, Mail, ListTodo, Network, FileStack, Presentation } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { motion, AnimatePresence } from "motion/react";
 import { GlowEffect } from "@/components/ui/glow-effect";
@@ -61,6 +61,14 @@ const INTEGRATIONS = [
     icon: Mail,
     color: "text-red-600",
     bgColor: "bg-red-600/10",
+  },
+  {
+    id: "slides",
+    name: "Slides",
+    description: "Generate AI-powered presentation outlines and create Google Slides.",
+    icon: Presentation,
+    color: "text-teal-500",
+    bgColor: "bg-teal-500/10",
   },
   {
     id: "pdf",

--- a/hooks/use-integration-handlers.ts
+++ b/hooks/use-integration-handlers.ts
@@ -75,6 +75,13 @@ export function useIntegrationHandlers({
       } else if (id === "tasks") {
         setIsTasksConnected(true);
       }
+
+      if (id === "slides" && !authData.hasSlidesScopes) {
+        const width = 600, height = 700;
+        const left = window.screen.width / 2 - width / 2;
+        const top = window.screen.height / 2 - height / 2;
+        window.open("/api/auth/google?service=slides", "GoogleSlidesAuth", `width=${width},height=${height},left=${left},top=${top}`);
+      }
       
       await reloadIntegrations();
       

--- a/lib/google-calendar.ts
+++ b/lib/google-calendar.ts
@@ -193,7 +193,7 @@ export async function getValidAccessToken(userId: string): Promise<string | null
  * @param state - State parameter for CSRF protection
  * @param service - Which service to authorize: 'calendar', 'forms', or 'all'
  */
-export function getAuthorizationUrl(state?: string, service: 'calendar' | 'forms' | 'tasks' | 'all' = 'calendar'): string {
+export function getAuthorizationUrl(state?: string, service: 'calendar' | 'forms' | 'tasks' | 'slides' | 'all' = 'calendar'): string {
   let scopes: string[];
   switch (service) {
     case 'forms':
@@ -201,6 +201,9 @@ export function getAuthorizationUrl(state?: string, service: 'calendar' | 'forms
       break;
     case 'tasks':
       scopes = GOOGLE_CALENDAR_SCOPES; // Tasks scopes are included in calendar scopes
+      break;
+    case 'slides':
+      scopes = GOOGLE_FORMS_SCOPES; // includes drive.file used for Slides upload
       break;
     case 'all':
       scopes = GOOGLE_ALL_SCOPES;

--- a/lib/google-slides.ts
+++ b/lib/google-slides.ts
@@ -1,0 +1,67 @@
+import { getValidAccessToken } from "@/lib/google-calendar";
+
+const DEFAULT_USER_ID = "default-user";
+
+export async function uploadPresentationToDrive(name: string, pptxBuffer: Buffer) {
+  const accessToken = await getValidAccessToken(DEFAULT_USER_ID);
+  if (!accessToken) {
+    throw new Error("Google authentication required for Slides upload");
+  }
+
+  const boundary = `agent0-${Date.now()}`;
+  const metadata = {
+    name,
+    mimeType: "application/vnd.google-apps.presentation",
+  };
+
+  const body = Buffer.concat([
+    Buffer.from(`--${boundary}\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n${JSON.stringify(metadata)}\r\n`),
+    Buffer.from(`--${boundary}\r\nContent-Type: application/vnd.openxmlformats-officedocument.presentationml.presentation\r\n\r\n`),
+    pptxBuffer,
+    Buffer.from(`\r\n--${boundary}--`),
+  ]);
+
+  const response = await fetch("https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart&fields=id,webViewLink,thumbnailLink", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": `multipart/related; boundary=${boundary}`,
+    },
+    body,
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Drive upload failed (${response.status}): ${errorText}`);
+  }
+
+  const data = await response.json();
+  return {
+    fileId: data.id as string,
+    webViewLink: data.webViewLink as string,
+    thumbnailLink: data.thumbnailLink as string | undefined,
+  };
+}
+
+export async function setFilePermission(fileId: string, role: "reader" | "writer" = "reader", type: "anyone" | "user" = "anyone") {
+  const accessToken = await getValidAccessToken(DEFAULT_USER_ID);
+  if (!accessToken) {
+    throw new Error("Google authentication required for setting permissions");
+  }
+
+  const response = await fetch(`https://www.googleapis.com/drive/v3/files/${fileId}/permissions`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ role, type }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Failed to set permission (${response.status}): ${errorText}`);
+  }
+
+  return { success: true };
+}

--- a/lib/pptx-generator.ts
+++ b/lib/pptx-generator.ts
@@ -1,0 +1,108 @@
+
+export type SlideType = "title" | "content" | "section-divider" | "two-column" | "image-focus" | "quote";
+
+export interface SlideDefinition {
+  id: string;
+  type: SlideType;
+  title: string;
+  subtitle?: string;
+  content: string[];
+  speakerNotes?: string;
+  imageQuery?: string;
+  imageUrl?: string;
+  quoteText?: string;
+  quoteAttribution?: string;
+}
+
+export interface SlideOutline {
+  title: string;
+  theme: {
+    primaryColor: string;
+    secondaryColor: string;
+    accentColor: string;
+    fontFamily: string;
+  };
+  slides: SlideDefinition[];
+}
+
+function safeColor(input: string, fallback: string) {
+  const normalized = (input || "").replace("#", "").trim();
+  return /^[0-9A-Fa-f]{6}$/.test(normalized) ? normalized : fallback;
+}
+
+export async function generatePptxBuffer(outline: SlideOutline): Promise<Buffer> {
+  const runtimeRequire = eval("require");
+  const PptxGenJS = runtimeRequire("pptxgenjs");
+  const pptx = new PptxGenJS();
+  pptx.layout = "LAYOUT_WIDE";
+  pptx.author = "Agent0";
+  pptx.company = "Agent0";
+  pptx.subject = outline.title;
+  pptx.title = outline.title;
+
+  const primary = safeColor(outline.theme?.primaryColor, "1D4ED8");
+  const secondary = safeColor(outline.theme?.secondaryColor, "0F172A");
+  const accent = safeColor(outline.theme?.accentColor, "F59E0B");
+  const fontFace = outline.theme?.fontFamily || "Aptos";
+
+  for (const slideDef of outline.slides) {
+    const slide = pptx.addSlide();
+
+    switch (slideDef.type) {
+      case "title":
+        slide.background = { color: primary };
+        slide.addText(slideDef.title, { x: 0.7, y: 1.8, w: 12, h: 1, color: "FFFFFF", fontFace, fontSize: 38, bold: true });
+        if (slideDef.subtitle) {
+          slide.addText(slideDef.subtitle, { x: 0.7, y: 3.0, w: 12, h: 1, color: "E2E8F0", fontFace, fontSize: 20 });
+        }
+        break;
+
+      case "section-divider":
+        slide.background = { color: secondary };
+        slide.addShape(pptx.ShapeType.rect, { x: 0.7, y: 2.8, w: 2.3, h: 0.1, fill: { color: accent }, line: { color: accent } });
+        slide.addText(slideDef.title, { x: 0.7, y: 3.1, w: 12, h: 1, color: "FFFFFF", fontFace, fontSize: 34, bold: true });
+        break;
+
+      case "two-column":
+        slide.addText(slideDef.title, { x: 0.6, y: 0.4, w: 12, h: 0.8, color: secondary, fontFace, fontSize: 30, bold: true });
+        slide.addShape(pptx.ShapeType.line, { x: 6.6, y: 1.5, w: 0, h: 5.4, line: { color: "CBD5E1", pt: 1 } });
+        slide.addText((slideDef.content || []).slice(0, Math.ceil(slideDef.content.length / 2)).map((t) => ({ text: `• ${t}`, options: { bullet: { indent: 16 } } })), { x: 0.8, y: 1.6, w: 5.4, h: 4.8, color: "1E293B", fontFace, fontSize: 18 });
+        slide.addText((slideDef.content || []).slice(Math.ceil(slideDef.content.length / 2)).map((t) => ({ text: `• ${t}`, options: { bullet: { indent: 16 } } })), { x: 6.9, y: 1.6, w: 5.4, h: 4.8, color: "1E293B", fontFace, fontSize: 18 });
+        break;
+
+      case "image-focus":
+        slide.addText(slideDef.title, { x: 0.6, y: 0.4, w: 12, h: 0.7, color: secondary, fontFace, fontSize: 28, bold: true });
+        if (slideDef.imageUrl) {
+          slide.addImage({ path: slideDef.imageUrl, x: 0.8, y: 1.2, w: 11.7, h: 4.8 });
+        }
+        if (slideDef.subtitle) {
+          slide.addText(slideDef.subtitle, { x: 0.8, y: 6.2, w: 11.7, h: 0.5, color: "334155", fontFace, fontSize: 16, italic: true });
+        }
+        break;
+
+      case "quote":
+        slide.addShape(pptx.ShapeType.rect, { x: 0, y: 0, w: 13.33, h: 7.5, fill: { color: "F8FAFC" }, line: { color: "F8FAFC" } });
+        slide.addText(`“${slideDef.quoteText || slideDef.title}”`, { x: 1.2, y: 2.1, w: 10.8, h: 2.2, color: secondary, fontFace, fontSize: 34, italic: true, align: "center", valign: "mid" });
+        if (slideDef.quoteAttribution) {
+          slide.addText(`— ${slideDef.quoteAttribution}`, { x: 1.2, y: 4.8, w: 10.8, h: 0.6, color: primary, fontFace, fontSize: 16, align: "center" });
+        }
+        break;
+
+      case "content":
+      default:
+        slide.addText(slideDef.title, { x: 0.6, y: 0.4, w: 12, h: 0.7, color: secondary, fontFace, fontSize: 30, bold: true });
+        slide.addText((slideDef.content || []).map((t) => ({ text: `• ${t}`, options: { bullet: { indent: 16 } } })), { x: 0.9, y: 1.5, w: slideDef.imageUrl ? 6.2 : 11.4, h: 5.5, color: "1E293B", fontFace, fontSize: 20, breakLine: true });
+        if (slideDef.imageUrl) {
+          slide.addImage({ path: slideDef.imageUrl, x: 7.3, y: 1.6, w: 5.4, h: 4.2 });
+        }
+        break;
+    }
+
+    if (slideDef.speakerNotes) {
+      slide.addNotes(slideDef.speakerNotes);
+    }
+  }
+
+  const arrayBuffer = await pptx.write({ outputType: "arraybuffer" });
+  return Buffer.from(arrayBuffer);
+}

--- a/lib/unsplash.ts
+++ b/lib/unsplash.ts
@@ -1,0 +1,53 @@
+const UNSPLASH_API_BASE = "https://api.unsplash.com";
+
+export interface UnsplashImageResult {
+  id: string;
+  url: string;
+  thumbUrl: string;
+  altDescription: string;
+  photographer: string;
+  downloadUrl: string;
+}
+
+export async function searchImages(query: string, count = 1): Promise<UnsplashImageResult[]> {
+  const accessKey = process.env.UNSPLASH_ACCESS_KEY;
+
+  if (!accessKey) {
+    throw new Error("UNSPLASH_ACCESS_KEY is not configured");
+  }
+
+  const response = await fetch(
+    `${UNSPLASH_API_BASE}/search/photos?query=${encodeURIComponent(query)}&per_page=${Math.max(1, Math.min(count, 10))}&orientation=landscape`,
+    {
+      headers: {
+        Authorization: `Client-ID ${accessKey}`,
+      },
+    }
+  );
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Unsplash search failed (${response.status}): ${errorText}`);
+  }
+
+  const payload = await response.json();
+  const images = (payload.results || []).map((item: any) => ({
+    id: item.id,
+    url: item.urls?.regular || item.urls?.full,
+    thumbUrl: item.urls?.small || item.urls?.thumb,
+    altDescription: item.alt_description || item.description || "Unsplash image",
+    photographer: item.user?.name || "Unknown photographer",
+    downloadUrl: item.links?.download_location || "",
+  })) as UnsplashImageResult[];
+
+  // Required by Unsplash API guidelines to trigger download endpoint.
+  await Promise.all(
+    images
+      .filter((image) => image.downloadUrl)
+      .map((image) =>
+        fetch(`${image.downloadUrl}${image.downloadUrl.includes("?") ? "&" : "?"}client_id=${accessKey}`).catch(() => null)
+      )
+  );
+
+  return images;
+}

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "tokenlens": "^1.3.1",
     "use-stick-to-bottom": "^1.1.1",
     "uuid": "^13.0.0",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "pptxgenjs": "^3.12.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
### Motivation

- Add an end-to-end `@slides` agent flow so the model can generate structured slide outlines, let the user edit them in a client-side generative UI, fetch Unsplash images, produce a PPTX, and upload/convert it to Google Slides with user approval.
- Keep the pipeline structured (Zod schemas) so the same `SlideOutline` feeds the editor, image search, PPTX generator, and Drive upload.
- Provide HITL checkpoints (outline review via `addToolOutput` and final upload via `needsApproval`) to avoid accidental uploads.
- Make the slide tooling robust by adding `experimental_repairToolCall` support to self-correct malformed tool inputs during streaming.

### Description

- Introduces the slides toolset and prompt: added `ai/slides-tools.ts` with Zod schemas and three tools (`reviewSlideOutline`, `searchUnsplashImages`, `createGoogleSlidesPresentation`) and `ai/prompts/slides.ts` with agent guidance.
- Adds backend helpers: `lib/unsplash.ts` (Unsplash search + download ping), `lib/pptx-generator.ts` (PPTX generation using `pptxgenjs` at runtime), `lib/google-slides.ts` (Drive multipart upload + permission helper), and a fallback API route `app/api/slides/upload/route.ts`.
- Adds client UI pieces: `components/ai-elements/slide-outline-editor.tsx` (generative outline editor using `addToolOutput`), `components/ai-elements/slides-approval.tsx` (approval UI using `addToolApprovalResponse`), and `components/ai-elements/slides-result.tsx` (final result display), plus message rendering in `components/ai-elements/message-list.tsx` for all slides tool states.
- Wires slides into the chat flow and auth: integrated `slidesTools` into `app/api/chat/route.ts` (aliases: `slides|presentation|ppt`), enabled `experimental_repairToolCall` when slides are active, passed `addToolOutput`/`addToolApprovalResponse` through `useChat` in `components/chat-ui.tsx`, added slides entry to `components/integrations-modal.tsx` and marketplace, and extended Google OAuth routes/handlers (`app/api/auth/google*`, `lib/google-calendar.ts`, `hooks/use-integration-handlers.ts`) to support `service=slides` (uses `drive.file` scope via existing forms scopes mapping).
- Added `pptxgenjs` to `package.json` and load it at runtime in `lib/pptx-generator.ts` using a dynamic `require` pattern to avoid build-time resolution in this environment.

### Testing

- Attempted dependency install: `npm install pptxgenjs` failed in this environment with `403 Forbidden` from the npm registry, so the package was added to `package.json` but could not be fetched here.
- Build: `npm run build` ran and failed due to environment constraints (blocked Google Fonts fetch for the `Geist` fonts) and missing runtime publishable key for `@clerk/nextjs`, so a production build could not be completed in this environment.
- Lint: `npm run lint` was run and reported many pre-existing TypeScript/Eslint issues across the repo; the slides changes themselves compile but the repo has numerous unrelated lint errors that prevent a clean lint pass in this environment.
- Dev run / UI smoke: `npm run dev` starts but runtime rendering was blocked by missing Clerk publishable key; a Playwright screenshot attempt timed out because the dev server could not render the full UI under these constraints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c3eb2829c8323b85c1cb293ddad1d)