### PR TITLE
feat: Update email fetching logic to retrieve unread messages from th…

### DIFF
--- a/app/api/glance/summary/route.ts
+++ b/app/api/glance/summary/route.ts
@@ -7,7 +7,7 @@ const GMAIL_API_BASE = "https://www.googleapis.com/gmail/v1";
 /**
  * GET /api/glance/summary
  * Returns live counts for the "At a Glance" widget:
- * - emailCount:   unread inbox emails received today
+ * - emailCount:   unread inbox emails from the last 7 days
  * - meetingCount: today's timed calendar events (fallback: Gmail ICS invites today)
  */
 export async function GET() {
@@ -22,11 +22,13 @@ export async function GET() {
     });
   }
 
-  // Today's date in Gmail `after:` format (YYYY/MM/DD)
+  // Date 7 days ago in Gmail `after:` format (YYYY/MM/DD)
   const today = new Date();
-  const dateStr = `${today.getFullYear()}/${String(today.getMonth() + 1).padStart(2, "0")}/${String(today.getDate()).padStart(2, "0")}`;
+  const sevenDaysAgo = new Date(today);
+  sevenDaysAgo.setDate(today.getDate() - 7);
+  const dateStr = `${sevenDaysAgo.getFullYear()}/${String(sevenDaysAgo.getMonth() + 1).padStart(2, "0")}/${String(sevenDaysAgo.getDate()).padStart(2, "0")}`;
 
-  // ── Email count: unread inbox messages received today ──────────────────────
+  // ── Email count: unread inbox messages received in the last 7 days ─────────
   // Use maxResults=50 and count actual messages[] — resultSizeEstimate is a
   // rough global estimate and does NOT reflect the `after:` date filter.
   let emailCount = 0;

--- a/components/email-card-carousel.tsx
+++ b/components/email-card-carousel.tsx
@@ -249,8 +249,8 @@ export function EmailCardCarousel({ isGmailConnected = false, selectedModel = "g
       setIsLoading(true);
       setError(null);
       try {
-        // Step 1: Fetch 20 unread messages from the last 2 days
-        const msgRes = await fetch("/api/gmail/messages?maxResults=20&q=is:unread%20newer_than:2d");
+        // Step 1: Fetch unread inbox messages from the past week
+        const msgRes = await fetch("/api/gmail/messages?maxResults=20&q=is:unread%20is:inbox%20newer_than:7d");
         const msgData = await msgRes.json();
 
         if (msgData.error || !msgData.messages) {
@@ -322,17 +322,16 @@ export function EmailCardCarousel({ isGmailConnected = false, selectedModel = "g
           };
         });
 
-        // Filter: keep high + medium importance, take top 10, sort by importance then date
+        // Keep all unread inbox messages (including low importance), sorted by importance then date.
         const importanceOrder = { high: 0, medium: 1, low: 2 };
         const filtered = enriched
-          .filter((e) => e.importance === "high" || e.importance === "medium" || !e.importance)
           .sort((a, b) => {
             const ia = importanceOrder[a.importance || "low"];
             const ib = importanceOrder[b.importance || "low"];
             if (ia !== ib) return ia - ib;
             return new Date(b.date).getTime() - new Date(a.date).getTime();
           })
-          .slice(0, 10);
+          .slice(0, 20);
 
         // Step 3: Fetch profile pictures from Google People API (best-effort)
         const uniqueEmails = [...new Set(filtered.map((e) => e.fromEmail).filter(Boolean))];


### PR DESCRIPTION
This pull request updates the logic for fetching and displaying unread Gmail messages, expanding the time window from 1–2 days to the past 7 days and adjusting filtering and sorting behavior. The changes ensure that more recent unread emails are counted and displayed, and that all unread inbox messages are considered, not just those marked as high or medium importance.

**Updates to email count and message fetching:**

* The `/api/glance/summary` endpoint now counts unread inbox emails from the last 7 days instead of just those received today, updating both the API documentation and the date calculation logic. [[1]](diffhunk://#diff-ea5e9fb9d7f663c2f58f8b65a869dc84a2d6f09659e09be74e039808dfbf3250L10-R10) [[2]](diffhunk://#diff-ea5e9fb9d7f663c2f58f8b65a869dc84a2d6f09659e09be74e039808dfbf3250L25-R31)
* The `EmailCardCarousel` component fetches unread inbox messages from the past week (7 days) instead of the last 2 days, ensuring a broader view of recent unread emails.

**Changes to email filtering and display:**

* The email carousel now includes all unread inbox messages (regardless of importance), sorts them by importance and date, and displays up to 20 emails instead of filtering for only high/medium importance and limiting to 10.…e past week