### PR TITLE
Fix AI reply generation in email cards

### DIFF
--- a/app/api/gmail/reply/route.ts
+++ b/app/api/gmail/reply/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cohere } from "@ai-sdk/cohere";
+import { generateText } from "ai";
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { subject, snippet, from, to } = body;
+
+    if (!subject && !snippet) {
+      return NextResponse.json({ error: true, message: "Missing email content" }, { status: 400 });
+    }
+
+    const prompt = `You are a helpful AI assistant that writes professional email replies.
+
+Write a concise, professional reply to the following email.
+
+From: ${from || "Unknown"}
+To: ${to || "me"}
+Subject: ${subject}
+Email Snippet: ${snippet}
+
+The reply should be 2-4 sentences, directly addressing the sender's context and any requests. Just return the text of the reply, nothing else.`;
+
+    const result = await generateText({
+      model: cohere("command-r-08-2024"),
+      prompt,
+    });
+
+    return NextResponse.json({
+      error: false,
+      reply: result.text.trim(),
+    });
+  } catch (error) {
+    console.error("Error generating reply:", error);
+    return NextResponse.json(
+      { error: true, message: error instanceof Error ? error.message : "Failed to generate reply" },
+      { status: 500 }
+    );
+  }
+}

--- a/components/email-card-carousel.tsx
+++ b/components/email-card-carousel.tsx
@@ -807,17 +807,19 @@ function ExpandedEmailCard({
     setReplyVisible(true);
     setGenerating(true);
     try {
-      const res = await fetch("/api/gmail/summarize", {
+      const res = await fetch("/api/gmail/reply", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          messages: [{ subject: email.subject, snippet: email.snippet, from: email.fromName || email.fromEmail, to: email.to }],
-          model: selectedModel,
+          subject: email.subject,
+          snippet: email.snippet,
+          from: email.fromName || email.fromEmail,
+          to: email.to
         }),
       });
       const data = await res.json();
-      if (!data.error && data.emails?.[0]?.suggestedReply) {
-        revealReply(data.emails[0].suggestedReply);
+      if (!data.error && data.reply) {
+        revealReply(data.reply);
       }
     } finally {
       setGenerating(false);


### PR DESCRIPTION
Creates a new API route `/api/gmail/reply` to handle generating replies using the Cohere model (`command-r-08-2024`). Updates the email card carousel component to call this endpoint instead of the summarize endpoint.

---
*PR created automatically by Jules for task [10694675811475541006](https://jules.google.com/task/10694675811475541006) started by @RealNickey*